### PR TITLE
Using start time to avoid overflowing tickcount.

### DIFF
--- a/TESReloaded/Core/ShaderManager.cpp
+++ b/TESReloaded/Core/ShaderManager.cpp
@@ -669,6 +669,9 @@ void ShaderManager::InitializeConstants() {
 	ShaderConst.BloodLens.Percent = 0.0f;
 	ShaderConst.SnowAccumulation.Params.w = 0.0f;
 	ShaderConst.WetWorld.Data.x = 0.0f;
+	LARGE_INTEGER PerformanceCount;
+	QueryPerformanceCounter(&PerformanceCount);
+	PerformanceStartingTime = PerformanceCount.QuadPart;
 }
 
 void ShaderManager::UpdateConstants() {
@@ -687,9 +690,12 @@ void ShaderManager::UpdateConstants() {
 	float weatherPercent = WorldSky->weatherPercent;
 
 	QueryPerformanceCounter(&PerformanceCount);
-	Tick = (double)PerformanceCount.QuadPart / (double)PerformanceFrequency;
+	PerformanceElapsedMicroseconds.QuadPart = PerformanceCount.QuadPart - PerformanceStartingTime;
+	Tick = PerformanceElapsedMicroseconds.QuadPart / PerformanceFrequency;
+	PerformanceElapsedMicroseconds.QuadPart *= 1000;
+	PerformanceElapsedMicroseconds.QuadPart /= PerformanceFrequency;
 	ShaderConst.Tick.x = Tick;
-	ShaderConst.Tick.y = (double)PerformanceCount.QuadPart * 1000.0 / (double)PerformanceFrequency;
+	ShaderConst.Tick.y = PerformanceElapsedMicroseconds.QuadPart;
 	TheFrameRateManager->SetFrameTime(Tick);
 	IsThirdPersonView = Player->IsThirdPersonView(TheSettingManager->SettingsMain.CameraMode.Enabled, TheRenderManager->FirstPersonView);
 	TheRenderManager->GetSceneCameraData();

--- a/TESReloaded/Core/ShaderManager.h
+++ b/TESReloaded/Core/ShaderManager.h
@@ -273,7 +273,9 @@ public:
 	
 	struct					FrameVS { float x, y, z, u, v; };
 
-	LONGLONG				PerformanceFrequency;
+	LONGLONG            PerformanceStartingTime;
+	LONGLONG            PerformanceFrequency;
+	LARGE_INTEGER       PerformanceElapsedMicroseconds;
 	ShaderConstants			ShaderConst;
 	CustomConstants			CustomConst;
 	IDirect3DTexture9*		SourceTexture;


### PR DESCRIPTION
This addresses the choppy water reflections and the missing rain effect (when the OS has a longer uptime).
https://www.tesreloaded.com/t93-rain-sound-and-weather-but-no-rain-particles
https://www.tesreloaded.com/t140-or-water-stuttering

I ran into these issues myself as I usually just sleep my PC rather than shutting it down fully, a local OR build with this fix resolved my issue (in oblivion, I don't have the others installed currently).

(This results in one additional subtraction per frame, in my opinion, not a big price to pay)

I see you guys don't have a PR template do tell if you want me to include anything (if there is an external test set somewhere or anything like that)